### PR TITLE
Предложения по улучшению

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.gitignore
+.dockerignore
+Dockerfile
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,19 @@
-# Build stage
-FROM node:22.20-alpine AS build
+# Use a single-stage build
+FROM node:22-alpine
 
 WORKDIR /app
 
 COPY package*.json ./
 
+# Install dependencies
 RUN npm ci --omit=dev --silent
 
 COPY . .
 
-# Final stage
-FROM gcr.io/distroless/nodejs20-debian12
-
-WORKDIR /app
-
-COPY --from=build /app ./
-
 # Create a non-root user and switch to it
-USER nonroot
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
 
 EXPOSE 3000
 
-CMD ["index.js"]
+CMD ["node", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-FROM node:20 AS build
+FROM node:22.20-alpine AS build
 
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci --omit=dev --silent
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM node:20 AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+# Final stage
+FROM gcr.io/distroless/nodejs20-debian12
+
+WORKDIR /app
+
+COPY --from=build /app ./
+
+# Create a non-root user and switch to it
+USER nonroot
+
+EXPOSE 3000
+
+CMD ["index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,7 +2,10 @@ import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { users } from './data/index.js';
 
-export const JWT_SECRET = process.env.JWT_SECRET || 'your_jwt_secret';
+export const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET is not set');
+}
 
 const opts = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,11 @@ app.use(bookingsRouter);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use('/static', express.static(path.join(__dirname, '../static')));
 
+app.get('/api-docs.json', (_req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.json(swaggerSpec);
+});
+
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
-const port = process.env.PORT || 3022;
+const port = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(cors());


### PR DESCRIPTION
### Предложение по улучшению

##   Проблема:
  В настоящее время отсутствует возможность получить спецификацию OpenAPI в машиночитаемом формате (JSON). Это затрудняет автоматическую генерацию клиентов API (например, для фронтенда), что приводит к необходимости написания кода для взаимодействия с API вручную и возможным ошибкам.

##  Решение:
  Добавлен новый эндпоинт `/api-docs.json`, который отдает спецификацию OpenAPI, генерируемую swagger-jsdoc, в формате JSON.

##  Польза:
  Это изменение позволяет разработчикам и инструментам автоматизации легко получать актуальную спецификацию API. Как результат, можно автоматически генерировать типизированные клиенты для фронтенда или других сервисов, что значительно ускоряет разработку, снижает количество ошибок и упрощает поддержку кода.

##  Как использовать:
   1. Запустите бэкенд-сервер.
   2. Обратитесь по URL http://localhost:3000/api-docs.json, чтобы получить спецификацию.

  Например, для генерации клиента с помощью openapi-generator-cli можно использовать следующую команду:

  ```bash 
openapi --input http://localhost:3000/api-docs.json --output ./src/api/generated --useOptions --client axios --indent 2
```

## Docker образ

  Все изменения включены в Dockerfile. Если вы используете Docker для локальной разработки, после слияния этих изменений вам потребуется пересобрать ваш образ, чтобы новый эндпоинт стал доступен.

  Для пересборки образа выполните команду:
```bash docker build -t <tag_name> . ```